### PR TITLE
Switch from Color.jl to Colors.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 GeometricalPredicates 0.0.4
-Color
+Colors

--- a/src/VoronoiDelaunay.jl
+++ b/src/VoronoiDelaunay.jl
@@ -24,7 +24,7 @@ import GeometricalPredicates
 import GeometricalPredicates: geta, getb, getc
 
 import Base:push!, start, done, next, copy
-import Color: RGB, RGBA
+import Colors: RGB, RGBA
 
 if VERSION < v"0.4-"
 	import Base:sizehint
@@ -636,7 +636,7 @@ function push!{T<:AbstractPoint2D}(tess::DelaunayTessellation2D{T}, a::Array{T, 
 end
 
 intensity(c::RGB)  = c.b
-intensity(c::RGBA) = c.c.b
+intensity(c::RGBA) = c.b
 intensity(c) 	   = c.(1) # Workaround. Gray needs to be imported from images, which would take to long.
 
 # Create DelaunayTessellation with npts points from an image


### PR DESCRIPTION
Color.jl is deprecated in favour of the much more exciting and plural Colors.jl. I used the [migration script](https://github.com/JuliaGraphics/Colors.jl#migrating-from-colorjl) to make this change.