### PR TITLE
Expose getgena and getgenb

### DIFF
--- a/src/VoronoiDelaunay.jl
+++ b/src/VoronoiDelaunay.jl
@@ -16,7 +16,7 @@ export
 	start, next, done,
 	findindex, push!,
 	Point, Point2D, AbstractPoint2D, getx, gety, geta, getb, getc,
-	getplotxy
+	getgena, getgenb, getplotxy
 
 using Compat
 


### PR DESCRIPTION
The semantics of these functions is to get the points generating
adjacent cells of a Voronoi tesselation. Expose them so that this
information can be used.