### PR TITLE
Loosen dependency minimum requirements

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-GeometricalPredicates 0.1.0
-Colors 0.7.1
+GeometricalPredicates 0.0.5
+Colors 0.7


### PR DESCRIPTION
Most users will be on latest versions from Pkg.update, minimum versions
should document the lowest versions that would work correctly rather than
what you happened to test with. Via Pkg.pin, VoronoiDelaunay's tests passed
fine on master against Colors 0.7.0 and GeometricalPredicates 0.0.5