### PR TITLE
fix all deprecations and errors on Julia v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: julia
 julia:
-  - 0.6
+  - 0.7
+  - nightly
 notifications:
   email: false
 after_success:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.7
+julia 0.7-alpha
 GeometricalPredicates 0.0.5
 Colors 0.7

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 GeometricalPredicates 0.0.5
 Colors 0.7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using VoronoiDelaunay
 import VoronoiDelaunay: _pushunfixed!, _flipa!, _flipb!, _flipc!
+import GeometricalPredicates
 import GeometricalPredicates: incircle
-using Base.Test
+using Test
 
 @testset "VoronoiDelaunay tests" begin
     @testset begin
@@ -261,8 +262,8 @@ using Base.Test
         point_arr = Point2D[]
         n=10
         tess = DelaunayTessellation2D(n*n*10)
-        for x in linspace(1.001,1.999,n)
-            for y in linspace(1.001,1.999,n)
+        for x in range(1.001,stop=1.999,length=n)
+            for y in range(1.001,stop=1.999,length=n)
                 push!(point_arr, Point2D(x,y))
             end
         end


### PR DESCRIPTION
Happy [Upgradathon Friday](https://discourse.julialang.org/t/ann-introducing-upgradathon-fridays/12047)! 

This PR (along with https://github.com/JuliaGeometry/GeometricalPredicates.jl/pull/27 ) fixes all errors and warnings on Julia v0.7. It also bumps the minimum Julia version to v0.7. 

Notable changes:
* Removed all `const` attributes on local variables. These never did anything anyway and are now disallowed. 
* Fixed up some missing imports