### PR TITLE
Iterator for voronoiedges

### DIFF
--- a/src/VoronoiDelaunay.jl
+++ b/src/VoronoiDelaunay.jl
@@ -184,36 +184,40 @@ function delaunayedges(t::DelaunayTessellation2D)
     Channel(delaunayiterator)
 end
 
-# TODO: is an iterator faster?
-function voronoiedges(t::DelaunayTessellation2D)
-    visited = zeros(Bool, t._last_trig_index)
-    visited[1] = true
-    function voronoiiterator(c::Channel)
-        for ix in 2:t._last_trig_index
-            visited[ix] && continue
-            tr = t._trigs[ix]
-            visited[ix] = true
-            #isexternal(tr) && continue
-            cc = circumcenter(tr)
+struct VoronoiEdgeIterator{T <: DelaunayTessellation2D}
+    t::T
+end
+Base.IteratorSize(::VoronoiEdgeIterator) = Base.SizeUnknown()
+Base.eltype(::VoronoiEdgeIterator{<:DelaunayTessellation2D{T}}) where T = VoronoiEdge{T}
+function iterate(v::VoronoiEdgeIterator, state=(2, 1))
+    ix, tx = state
+    t = v.t
+    while ix <= t._last_trig_index
+        tr = t._trigs[ix]
+        cc = circumcenter(tr)
 
-            ix_na = tr._neighbour_a
-            if !visited[ix_na] #&& !isexternal(t._trigs[ix_na])
-                nb = t._trigs[ix_na]
-                put!(c, VoronoiEdge(cc, circumcenter(nb), getb(tr), getc(tr)))
-            end
-            ix_nb = tr._neighbour_b
-            if !visited[ix_nb] #&& !isexternal(t._trigs[ix_nb])
-                nb = t._trigs[ix_nb]
-                put!(c, VoronoiEdge(cc, circumcenter(nb), geta(tr), getc(tr)))
-            end
-            ix_nc = tr._neighbour_c
-            if !visited[ix_nc] #&& !isexternal(t._trigs[ix_nb])
-                nb = t._trigs[ix_nc]
-                put!(c, VoronoiEdge(cc, circumcenter(nb), geta(tr), getb(tr)))
-            end
+        ix_na = tr._neighbour_a
+        if tx <= 1 && ix_na > ix
+            nb = t._trigs[ix_na]
+            return (VoronoiEdge(cc, circumcenter(nb), getb(tr), getc(tr)), (ix, 2))
         end
+        ix_nb = tr._neighbour_b
+        if tx <= 2 && ix_nb > ix
+            nb = t._trigs[ix_nb]
+            return (VoronoiEdge(cc, circumcenter(nb), geta(tr), getc(tr)), (ix, 3))
+        end
+        ix_nc = tr._neighbour_c
+        if tx <= 3 && ix_nc > ix
+            nb = t._trigs[ix_nc]
+            return (VoronoiEdge(cc, circumcenter(nb), geta(tr), getb(tr)), (ix+1, 1))
+        end
+        tx = 1
+        ix += 1
     end
-    Channel(voronoiiterator)
+    nothing
+end
+function voronoiedges(t::DelaunayTessellation2D)
+    VoronoiEdgeIterator(t)
 end
 
 function voronoiedgeswithoutgenerators(t::DelaunayTessellation2D)


### PR DESCRIPTION
Change voronoiedges to return an iterator instead of a Channel.

In my use case this results in a 10-100x faster iteration over voronoiedges.