### PR TITLE
Revert breaking changes on DelaunayTessellation iteration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "VoronoiDelaunay"
 uuid = "72f80fcb-8c52-57d9-aff0-40c1a3526986"
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/VoronoiDelaunay.jl
+++ b/src/VoronoiDelaunay.jl
@@ -278,17 +278,22 @@ function voronoiedgeswithoutgenerators(t::DelaunayTessellation2D)
     VoronoiEdgeIteratorWithoutGenerator(t)
 end
 
+# TODO: for v0.5, remove TrigIter
+mutable struct TrigIter
+    ix::Int64
+end
 
-function iterate(t::DelaunayTessellation2D, ix::Int=2)
-    while ix <= t._last_trig_index && isexternal(@inbounds t._trigs[ix])
-        ix += 1
+# TODO: for v0.5, replace it by ix::Int
+function iterate(t::DelaunayTessellation2D, it::TrigIter=TrigIter(2))
+    while it.ix <= t._last_trig_index && isexternal(@inbounds t._trigs[it.ix])
+        it.ix += 1
     end
-    if ix > t._last_trig_index
+    if it.ix > t._last_trig_index
         return nothing
     end
-    trig = t._trigs[ix]
-    ix += 1
-    return (trig, ix)
+    trig = t._trigs[it.ix]
+    it.ix += 1
+    return (trig, it)
 end
 
 function findindex(tess::DelaunayTessellation2D{T}, p::T) where T<:AbstractPoint2D


### PR DESCRIPTION
Turns out this was breaking code that manually iterated through the tessellation. If we change it, it should come with a minor version bump. Introduced in #59.